### PR TITLE
Doesn't need to change the directory at buildkernel.sh

### DIFF
--- a/buildkernel.sh
+++ b/buildkernel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ~/android/kernel/mystery/
+# cd ~/android/kernel/mystery/
 export CROSS_COMPILE=~/android/toolchain/arm-eabi-4.8/bin/arm-eabi-
 export USE_CCACHE=1
 export ARCH=arm ARCH_MTK_PLATFORM=mt6580


### PR DESCRIPTION
Why?
First of all, not all of people use the same way of directory
Second, it is already in project root, so it is not usable again.